### PR TITLE
fix(update): ddr_init_v3m Unsigned difference expression compared to zero

### DIFF
--- a/drivers/renesas/common/ddr/ddr_a/ddr_init_v3m.c
+++ b/drivers/renesas/common/ddr/ddr_a/ddr_init_v3m.c
@@ -271,7 +271,7 @@ static uint32_t init_ddr_v3m_1600(void)
 		mmio_write_32(DBSC_DBPDRGA_0, 0xB3 + i * 0x20);
 		r7 = (mmio_read_32(DBSC_DBPDRGD_0) & 0x7);
 		r12 = (r5 >> 2);
-		if (r6 - r12 > 0) {
+		if ((int32_t)r6 - (int32_t)r12 > 0) {
 			mmio_write_32(DBSC_DBPDRGA_0, 0xB2 + i * 0x20);
 			r2 = (mmio_read_32(DBSC_DBPDRGD_0) & 0xFFFFFFF8);
 


### PR DESCRIPTION
fix the problem, the comparison should be rewritten to avoid unsigned underflow. The best way is to cast both `r6` and `r12` to a signed type (e.g., `int32_t`) before performing the subtraction and comparison. This ensures that if `r6 < r12`, the result will be negative, and the comparison will behave as intended. The fix should be applied only to the conditional on line 274 in `drivers/renesas/common/ddr/ddr_a/ddr_init_v3m.c`. No new imports or definitions are needed, as `int32_t` is already available via `<stdint.h>`.
